### PR TITLE
Separate commands on development environment

### DIFF
--- a/modules/discordutils/slashCommand.js
+++ b/modules/discordutils/slashCommand.js
@@ -28,6 +28,13 @@ function SlashCommandRegister(token, client) {
     for (const file of commandFiles) {
         const filePath = path.join(commandsPath, file);
         const command = require(filePath);
+
+        // prepend "zz" to command when running as development environment
+        if (process.env.NODE_ENV === 'development') {
+            command.data.name = `zz${command.data.name}`;
+            Object.keys(command.data.name_localizations).forEach(key => command.data.name_localizations[key] = `zz${command.data.name_localizations[key]}`);
+        }
+
         commandList.push(command.data.toJSON());
     }
 
@@ -56,25 +63,25 @@ function SlashCommandRegister(token, client) {
 async function SlashCommandHandler(interaction) {
     const command = interaction.client.commands.get(interaction.commandName);
 
-	if (!command) {
-		logger.error('discord.js', `No command matching ${interaction.commandName} was found.`);
-		return;
-	}
+    if (!command) {
+        logger.error('discord.js', `No command matching ${interaction.commandName} was found.`);
+        return;
+    }
 
-	try {
+    try {
         // defer reply and wait for command to write any message
         const isEphemeral = (command.extra && command.extra.ephemeral) || false;
         await interaction.deferReply({ ephemeral: isEphemeral });
         // launch command
-		await command.execute(interaction);
-	} catch (error) {
-		console.error(error);
-		if (interaction.replied || interaction.deferred) {
-			await interaction.followUp({ content: 'There was an error while executing this command!', ephemeral: true });
-		} else {
-			await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
-		}
-	}
+        await command.execute(interaction);
+    } catch (error) {
+        console.error(error);
+        if (interaction.replied || interaction.deferred) {
+            await interaction.followUp({ content: 'There was an error while executing this command!', ephemeral: true });
+        } else {
+            await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
+        }
+    }
 }
 
 module.exports = { load: SlashCommandLoader, handler: SlashCommandHandler, register: SlashCommandRegister };

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "chattybot",
-  "version": "2.1.0-experimental.0",
+  "version": "2.1.0-experimental.1",
   "description": "An Discord Text-To-Speech Bot",
   "main": "main.js",
   "scripts": {
     "start": "node .",
     "dev": "npm run development",
     "development": "NODE_ENV=development nodemon --inspect .",
-    "unregister": "UNREGISTER_SLASH=yes node ."
+    "unregister": "NODE_ENV=development UNREGISTER_SLASH=yes node ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Discord doesn't have an intuitive way of showing the same command in a separate bot.
Instead, it sorts every command by usage count, so it might confuse the user between the release and development versions of the application.
This change will try to minimize it by adding "zz" to every command in the development version.