### PR TITLE
Better slash command registration/unregistration

### DIFF
--- a/main.js
+++ b/main.js
@@ -25,9 +25,8 @@ client.once(Events.ClientReady, async c => {
     // check if user launched bot to register/unregister commands
     if (process.env.SLASH_ACTION === 'register')
         slash.register(config.token, c);
-    else if (process.env.SLASH_ACTION == 'unregister') {
+    else if (process.env.SLASH_ACTION == 'unregister')
         slash.unregister(config.token, c);
-    }
 
     // set bot activity message if available
     if (config.status && config.status !== '') c.user.setActivity(config.status);

--- a/main.js
+++ b/main.js
@@ -22,8 +22,10 @@ client.once(Events.ClientReady, async c => {
     // create voice session map
     logger.info('discord.js', `Connected to ${client.user.username}!`);
 
-    // check if user launched bot to unregister commands
-    if (process.env.UNREGISTER_SLASH == 'yes') {
+    // check if user launched bot to register/unregister commands
+    if (process.env.SLASH_ACTION === 'register')
+        slash.register(config.token, c);
+    else if (process.env.SLASH_ACTION == 'unregister') {
         const rest = new REST().setToken(config.token);
         try {
             logger.info('discord.js', 'Unregistering slash commands...');
@@ -41,11 +43,6 @@ client.once(Events.ClientReady, async c => {
 
     // set bot activity message if available
     if (config.status && config.status !== '') c.user.setActivity(config.status);
-
-    // register slash commands
-    //TODO: cache command data and register only when updated
-    logger.info('discord.js', 'Reloading slash commands...');
-    slash.register(config.token, c);
 
     // load registered slash commands
     slash.load(c);

--- a/main.js
+++ b/main.js
@@ -23,7 +23,7 @@ client.once(Events.ClientReady, async c => {
     logger.info('discord.js', `Connected to ${client.user.username}!`);
 
     // check if user launched bot to register/unregister commands
-    if (process.env.SLASH_ACTION === 'register')
+    if (process.env.SLASH_ACTION === 'register' || process.env.SLASH_ACTION === 'devRegister')
         slash.register(config.token, c);
     else if (process.env.SLASH_ACTION == 'unregister')
         slash.unregister(config.token, c);

--- a/main.js
+++ b/main.js
@@ -26,19 +26,7 @@ client.once(Events.ClientReady, async c => {
     if (process.env.SLASH_ACTION === 'register')
         slash.register(config.token, c);
     else if (process.env.SLASH_ACTION == 'unregister') {
-        const rest = new REST().setToken(config.token);
-        try {
-            logger.info('discord.js', 'Unregistering slash commands...');
-
-            // unregister global slash commands
-            await rest.put(Routes.applicationCommands(c.user.id), { body: [] });
-
-            logger.info('discord.js', 'Unregistered all slash commands.');
-        } catch (err) {
-            logger.error('discord.js', 'Failed to unregister slash command!');
-            logger.error('discord.js', err.stack ? err.stack : err);
-        }
-        process.exit();
+        slash.unregister(config.token, c);
     }
 
     // set bot activity message if available

--- a/main.js
+++ b/main.js
@@ -23,7 +23,7 @@ client.once(Events.ClientReady, async c => {
     logger.info('discord.js', `Connected to ${client.user.username}!`);
 
     // check if user launched bot to register/unregister commands
-    if (process.env.SLASH_ACTION === 'register' || process.env.SLASH_ACTION === 'devRegister')
+    if (process.env.SLASH_ACTION === 'register' || process.env.SLASH_ACTION === 'registerDev')
         slash.register(config.token, c);
     else if (process.env.SLASH_ACTION == 'unregister')
         slash.unregister(config.token, c);

--- a/modules/discordutils/slashCommand.js
+++ b/modules/discordutils/slashCommand.js
@@ -31,7 +31,7 @@ async function SlashCommandRegister(token, client) {
         const command = require(filePath);
 
         // prepend "zz" to command when running as development environment
-        if (process.env.NODE_ENV === 'development') {
+        if (process.env.SLASH_ACTION === 'devRegister') {
             command.data.name = `zz${command.data.name}`;
             Object.keys(command.data.name_localizations).forEach(key => command.data.name_localizations[key] = `zz${command.data.name_localizations[key]}`);
         }

--- a/modules/discordutils/slashCommand.js
+++ b/modules/discordutils/slashCommand.js
@@ -31,7 +31,7 @@ async function SlashCommandRegister(token, client) {
         const command = require(filePath);
 
         // check if user is trying to register development enviroment commands
-        if (process.env.SLASH_ACTION === 'devRegister') {
+        if (process.env.SLASH_ACTION === 'registerDev') {
             // prepend "zz" to command when running as development environment
             Object.keys(command.data.name_localizations).forEach(key => command.data.name_localizations[key] = `zz${command.data.name_localizations[key]}`);
             // prepend "(dev)" to description when running as development environment

--- a/modules/discordutils/slashCommand.js
+++ b/modules/discordutils/slashCommand.js
@@ -24,7 +24,7 @@ function SlashCommandLoader(client) {
 }
 
 // register slash command
-function SlashCommandRegister(token, client) {
+async function SlashCommandRegister(token, client) {
     const commandList = [];
     for (const file of commandFiles) {
         const filePath = path.join(commandsPath, file);
@@ -42,23 +42,39 @@ function SlashCommandRegister(token, client) {
     const rest = new REST({ version: '10' }).setToken(token);
 
     // and deploy your commands!
-    (async () => {
-        try {
-            logger.info('discord.js:slash', `Started registering/refreshing ${commandList.length} application (/) commands.`);
+    try {
+        logger.info('discord.js:slash', `Started registering/refreshing ${commandList.length} slash commands.`);
 
-            // The put method is used to fully refresh all commands in the guild with the current set
-            const data = await rest.put(
-                Routes.applicationCommands(client.user.id),
-                { body: commandList }
-            );
+        // The put method is used to fully refresh all commands in the guild with the current set
+        const data = await rest.put(
+            Routes.applicationCommands(client.user.id),
+            { body: commandList }
+        );
 
-            logger.info('discord.js:slash', `Successfully registered/refreshed ${data.length} application (/) commands.`);
-        } catch (err) {
-            // And of course, make sure you catch and log any errors!
-            logger.error('discord.js:slash', 'Error occured while registering/refreshing slash command!');
-            logger.error('discord.js:slash', err.stack ? err.stack : err);
-        }
-    })();
+        logger.info('discord.js:slash', `Successfully registered/refreshed ${data.length} slash commands.`);
+    } catch (err) {
+        // And of course, make sure you catch and log any errors!
+        logger.error('discord.js:slash', 'Error occured while registering/refreshing slash commands!');
+        logger.error('discord.js:slash', err.stack ? err.stack : err);
+    }
+    process.exit();
+}
+
+// unregister slash command
+async function SlashCommandUnregister(token, client) {
+    const rest = new REST().setToken(token);
+    try {
+        logger.info('discord.js:slash', 'Started unregistering slash commands.');
+
+        // unregister global slash commands
+        await rest.put(Routes.applicationCommands(client.user.id), { body: [] });
+
+        logger.info('discord.js:slash', 'Successfully unregistered slash commands.');
+    } catch (err) {
+        logger.error('discord.js:slash', 'Error occured while unregistering slash commands!');
+        logger.error('discord.js:slash', err.stack ? err.stack : err);
+    }
+    process.exit();
 }
 
 // handle slash commands
@@ -96,4 +112,9 @@ async function SlashCommandHandler(interaction) {
     }
 }
 
-module.exports = { load: SlashCommandLoader, handler: SlashCommandHandler, register: SlashCommandRegister };
+module.exports = {
+    load: SlashCommandLoader,
+    handler: SlashCommandHandler,
+    register: SlashCommandRegister,
+    unregister: SlashCommandUnregister
+};

--- a/modules/discordutils/slashCommand.js
+++ b/modules/discordutils/slashCommand.js
@@ -30,10 +30,13 @@ async function SlashCommandRegister(token, client) {
         const filePath = path.join(commandsPath, file);
         const command = require(filePath);
 
-        // prepend "zz" to command when running as development environment
+        // check if user is trying to register development enviroment commands
         if (process.env.SLASH_ACTION === 'devRegister') {
-            command.data.name = `zz${command.data.name}`;
+            // prepend "zz" to command when running as development environment
             Object.keys(command.data.name_localizations).forEach(key => command.data.name_localizations[key] = `zz${command.data.name_localizations[key]}`);
+            // prepend "(dev)" to description when running as development environment
+            Object.keys(command.data.description_localizations).forEach(key =>
+                command.data.description_localizations[key] = `(dev) ${command.data.description_localizations[key]}`);
         }
 
         commandList.push(command.data.toJSON());

--- a/modules/discordutils/slashCommand.js
+++ b/modules/discordutils/slashCommand.js
@@ -44,7 +44,7 @@ function SlashCommandRegister(token, client) {
     // and deploy your commands!
     (async () => {
         try {
-            logger.verbose('discord.js:slash', `Started refreshing ${commandList.length} application (/) commands.`);
+            logger.info('discord.js:slash', `Started registering/refreshing ${commandList.length} application (/) commands.`);
 
             // The put method is used to fully refresh all commands in the guild with the current set
             const data = await rest.put(
@@ -52,10 +52,10 @@ function SlashCommandRegister(token, client) {
                 { body: commandList }
             );
 
-            logger.verbose('discord.js:slash', `Successfully reloaded ${data.length} application (/) commands.`);
+            logger.info('discord.js:slash', `Successfully registered/refreshed ${data.length} application (/) commands.`);
         } catch (err) {
             // And of course, make sure you catch and log any errors!
-            logger.error('discord.js:slash', 'Error occured while reloading slash command!');
+            logger.error('discord.js:slash', 'Error occured while registering/refreshing slash command!');
             logger.error('discord.js:slash', err.stack ? err.stack : err);
         }
     })();

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "npm run development",
     "development": "NODE_ENV=development nodemon --inspect .",
     "register": "NODE_ENV=development SLASH_ACTION=register node .",
+    "devRegister": "NODE_ENV=development SLASH_ACTION=devRegister node .",
     "unregister": "NODE_ENV=development SLASH_ACTION=unregister node ."
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "dev": "npm run development",
     "development": "NODE_ENV=development nodemon --inspect .",
     "register": "NODE_ENV=development SLASH_ACTION=register node .",
-    "devRegister": "NODE_ENV=development SLASH_ACTION=devRegister node .",
+    "registerDev": "NODE_ENV=development SLASH_ACTION=registerDev node .",
+    "registerAndRun": "npm run register && npm run start",
+    "registerAndRunDev": "npm run registerDev && npm run development",
     "unregister": "NODE_ENV=development SLASH_ACTION=unregister node ."
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node .",
     "dev": "npm run development",
     "development": "NODE_ENV=development nodemon --inspect .",
-    "unregister": "NODE_ENV=development UNREGISTER_SLASH=yes node ."
+    "register": "NODE_ENV=development SLASH_ACTION=register node .",
+    "unregister": "NODE_ENV=development SLASH_ACTION=unregister node ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Automatic registration is convenient, but it might exceed the API quota and cause an error or severe launch delay.

- made register manual so user can run register only when needed.
- separated unregister code for better maintenance.
- added `registerAndRun`, `registerAndRunDev` job to correspond to switching to manual.